### PR TITLE
Add blog design preview page with 3 mockups

### DIFF
--- a/content/_includes/layouts/blog-post.njk
+++ b/content/_includes/layouts/blog-post.njk
@@ -6,15 +6,6 @@ mainClass: blog
   <header class="post-header">
     <p class="post-meta">
       <time datetime="{{ page.date.toISOString() }}">{{ page.date | readableDate }}</time>
-      {% if tags %}
-        <span class="post-tags">
-          {% for tag in tags | sort %}
-            {% if tag != "blog" %}
-              <a href="/blog/tags/{{ tag | slugify }}/">{{ tag }}</a>
-            {% endif %}
-          {% endfor %}
-        </span>
-      {% endif %}
     </p>
     <h1 class="post-title">{{ title }}</h1>
     {% if summary %}
@@ -24,5 +15,14 @@ mainClass: blog
   <div class="post-body">
     {{ content | safe }}
   </div>
-  <p class="post-back"><a href="/blog/">Back to Blog</a></p>
+  {% if tags %}
+    <div class="post-tags-footer">
+      {% for tag in tags | sort %}
+        {% if tag != "blog" %}
+          <a href="/blog/tags/{{ tag | slugify }}/">{{ tag }}</a>
+        {% endif %}
+      {% endfor %}
+    </div>
+  {% endif %}
+  <p class="post-back"><a href="/blog/">← Back to Blog</a></p>
 </article>

--- a/content/_includes/layouts/blog-post.njk
+++ b/content/_includes/layouts/blog-post.njk
@@ -15,14 +15,5 @@ mainClass: blog
   <div class="post-body">
     {{ content | safe }}
   </div>
-  {% if tags %}
-    <div class="post-tags-footer">
-      {% for tag in tags | sort %}
-        {% if tag != "blog" %}
-          <a href="/blog/tags/{{ tag | slugify }}/">{{ tag }}</a>
-        {% endif %}
-      {% endfor %}
-    </div>
-  {% endif %}
   <p class="post-back"><a href="/blog/">← Back to Blog</a></p>
 </article>

--- a/content/blog/blog.11tydata.js
+++ b/content/blog/blog.11tydata.js
@@ -9,6 +9,8 @@ module.exports = {
       data.page.inputPath.endsWith(".md")
         ? "layouts/blog-post.njk"
         : data.layout,
+    mainClass: (data) =>
+      data.page.inputPath.endsWith(".md") ? "blog" : data.mainClass,
     ogType: (data) =>
       data.page.inputPath.endsWith(".md") ? "article" : data.ogType,
     tags: (data) => {

--- a/content/blog/design-preview.njk
+++ b/content/blog/design-preview.njk
@@ -1,0 +1,1000 @@
+---
+layout: layouts/base.njk
+title: Blog Design Preview
+description: Compare 3 blog design mockups
+permalink: /blog/design-preview/
+mainClass: design-preview
+---
+
+<style>
+/* ============================================
+   DESIGN PREVIEW PAGE STYLES
+   ============================================ */
+.design-preview-page {
+  width: min(1400px, 95vw);
+  margin: 0 auto 80px;
+}
+
+.preview-header {
+  text-align: center;
+  margin-bottom: 60px;
+}
+
+.preview-header h1 {
+  font-family: "DM Serif Display", serif;
+  font-size: clamp(32px, 5vw, 48px);
+  margin: 0 0 16px;
+  letter-spacing: -0.5px;
+}
+
+.preview-header p {
+  font-size: 18px;
+  color: rgba(var(--color-forest-rgb), 0.7);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.design-section {
+  margin-bottom: 80px;
+  padding: 40px;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-highlight);
+  border-radius: 24px;
+}
+
+.design-label {
+  display: inline-block;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 3px;
+  font-weight: 800;
+  padding: 6px 14px;
+  background-color: var(--color-forest);
+  color: var(--color-mint);
+  border-radius: 999px;
+  margin-bottom: 24px;
+}
+
+.design-description {
+  font-size: 14px;
+  color: rgba(var(--color-forest-rgb), 0.7);
+  margin-bottom: 32px;
+  max-width: 600px;
+}
+
+/* Sample post data for mockups */
+.mockup-container {
+  background-color: var(--color-mint);
+  border-radius: 16px;
+  padding: 40px;
+  border: 1px solid var(--color-highlight);
+}
+
+/* ============================================
+   DESIGN 1: MEDIUM-INSPIRED MINIMAL
+   Clean, reading-focused with generous whitespace
+   ============================================ */
+.design-1 .blog-index-v1 {
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.design-1 .blog-header-v1 {
+  text-align: center;
+  padding-bottom: 48px;
+  margin-bottom: 48px;
+  border-bottom: 1px solid var(--color-highlight);
+}
+
+.design-1 .blog-title-v1 {
+  font-family: "DM Serif Display", serif;
+  font-size: 48px;
+  margin: 0 0 12px;
+  letter-spacing: -1px;
+}
+
+.design-1 .blog-subtitle-v1 {
+  font-size: 18px;
+  color: rgba(var(--color-forest-rgb), 0.65);
+  margin: 0 0 24px;
+  line-height: 1.5;
+}
+
+.design-1 .blog-actions-v1 {
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+}
+
+.design-1 .blog-actions-v1 a {
+  font-size: 13px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: rgba(var(--color-forest-rgb), 0.6);
+  border-bottom: none;
+  transition: color 0.2s ease;
+}
+
+.design-1 .blog-actions-v1 a:hover {
+  color: var(--color-forest);
+  background: none;
+}
+
+.design-1 .blog-list-v1 {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.design-1 .post-card-v1 {
+  padding: 40px 0;
+  border-bottom: 1px solid var(--color-highlight);
+}
+
+.design-1 .post-card-v1:first-child {
+  padding-top: 0;
+}
+
+.design-1 .post-card-v1:last-child {
+  border-bottom: none;
+}
+
+.design-1 .post-meta-v1 {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0 0 16px;
+  font-size: 13px;
+  color: rgba(var(--color-forest-rgb), 0.55);
+}
+
+.design-1 .post-meta-v1 time {
+  font-weight: 500;
+}
+
+.design-1 .post-meta-v1 .reading-time {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.design-1 .post-meta-v1 .reading-time::before {
+  content: "·";
+}
+
+.design-1 .post-title-v1 {
+  font-family: "DM Serif Display", serif;
+  font-size: 28px;
+  line-height: 1.25;
+  margin: 0 0 12px;
+  letter-spacing: -0.3px;
+}
+
+.design-1 .post-title-v1 a {
+  color: inherit;
+  border-bottom: none;
+  transition: color 0.2s ease;
+}
+
+.design-1 .post-title-v1 a:hover {
+  color: rgba(var(--color-forest-rgb), 0.7);
+  background: none;
+}
+
+.design-1 .post-summary-v1 {
+  font-size: 17px;
+  line-height: 1.6;
+  color: rgba(var(--color-forest-rgb), 0.75);
+  margin: 0 0 16px;
+}
+
+.design-1 .post-tags-v1 {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.design-1 .post-tags-v1 a {
+  font-size: 12px;
+  font-weight: 500;
+  color: rgba(var(--color-forest-rgb), 0.55);
+  border-bottom: none;
+  padding: 0;
+}
+
+.design-1 .post-tags-v1 a:hover {
+  color: var(--color-forest);
+  background: none;
+}
+
+/* ============================================
+   DESIGN 2: EDITORIAL / MAGAZINE STYLE
+   Visual with featured images, refined grid
+   ============================================ */
+.design-2 .blog-index-v2 {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.design-2 .blog-header-v2 {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding-bottom: 32px;
+  margin-bottom: 40px;
+  border-bottom: 2px solid var(--color-forest);
+}
+
+.design-2 .blog-title-v2 {
+  font-family: "DM Serif Display", serif;
+  font-size: 56px;
+  margin: 0;
+  letter-spacing: -1.5px;
+  line-height: 1;
+}
+
+.design-2 .blog-actions-v2 {
+  display: flex;
+  gap: 20px;
+}
+
+.design-2 .blog-actions-v2 a {
+  font-size: 12px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  font-weight: 700;
+  border-bottom: none;
+  padding: 8px 16px;
+  border: 1px solid var(--color-forest);
+  border-radius: 4px;
+  transition: all 0.2s ease;
+}
+
+.design-2 .blog-actions-v2 a:hover {
+  background-color: var(--color-forest);
+  color: var(--color-mint);
+}
+
+.design-2 .blog-list-v2 {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 32px;
+}
+
+@media (max-width: 768px) {
+  .design-2 .blog-list-v2 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.design-2 .post-card-v2 {
+  display: flex;
+  flex-direction: column;
+  background-color: var(--color-surface);
+  border-radius: 4px;
+  overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.design-2 .post-card-v2:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 40px rgba(var(--color-forest-rgb), 0.12);
+}
+
+.design-2 .post-card-v2.featured {
+  grid-column: span 2;
+  flex-direction: row;
+}
+
+@media (max-width: 768px) {
+  .design-2 .post-card-v2.featured {
+    grid-column: span 1;
+    flex-direction: column;
+  }
+}
+
+.design-2 .post-image-v2 {
+  aspect-ratio: 16 / 10;
+  background: linear-gradient(135deg, var(--color-highlight), var(--color-surface));
+  position: relative;
+  overflow: hidden;
+}
+
+.design-2 .post-card-v2.featured .post-image-v2 {
+  flex: 1;
+  aspect-ratio: auto;
+  min-height: 280px;
+}
+
+.design-2 .post-image-v2 img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.design-2 .post-image-v2 .placeholder-icon {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 48px;
+  color: rgba(var(--color-forest-rgb), 0.15);
+}
+
+.design-2 .post-content-v2 {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.design-2 .post-card-v2.featured .post-content-v2 {
+  flex: 1;
+  padding: 32px;
+  justify-content: center;
+}
+
+.design-2 .post-category-v2 {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-weight: 700;
+  color: rgba(var(--color-forest-rgb), 0.5);
+  margin: 0 0 12px;
+}
+
+.design-2 .post-title-v2 {
+  font-family: "DM Serif Display", serif;
+  font-size: 22px;
+  line-height: 1.3;
+  margin: 0 0 12px;
+  letter-spacing: -0.2px;
+}
+
+.design-2 .post-card-v2.featured .post-title-v2 {
+  font-size: 32px;
+}
+
+.design-2 .post-title-v2 a {
+  color: inherit;
+  border-bottom: none;
+}
+
+.design-2 .post-title-v2 a:hover {
+  background: none;
+}
+
+.design-2 .post-summary-v2 {
+  font-size: 15px;
+  line-height: 1.55;
+  color: rgba(var(--color-forest-rgb), 0.7);
+  margin: 0 0 16px;
+  flex-grow: 1;
+}
+
+.design-2 .post-footer-v2 {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 16px;
+  border-top: 1px solid var(--color-highlight);
+}
+
+.design-2 .post-date-v2 {
+  font-size: 12px;
+  color: rgba(var(--color-forest-rgb), 0.5);
+  font-weight: 500;
+}
+
+.design-2 .post-read-more-v2 {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  border-bottom: none;
+}
+
+.design-2 .post-read-more-v2:hover {
+  background: none;
+  text-decoration: underline;
+}
+
+/* ============================================
+   DESIGN 3: CLEAN LIST (STAMATIOU-INSPIRED)
+   Minimal hover effects, single column elegance
+   ============================================ */
+.design-3 .blog-index-v3 {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.design-3 .blog-header-v3 {
+  margin-bottom: 56px;
+}
+
+.design-3 .blog-header-v3 .author-intro {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.design-3 .blog-header-v3 .author-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--color-highlight), var(--color-surface));
+  overflow: hidden;
+}
+
+.design-3 .blog-header-v3 .author-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.design-3 .blog-header-v3 .author-name {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.design-3 .blog-title-v3 {
+  font-family: "DM Serif Display", serif;
+  font-size: 42px;
+  margin: 0 0 16px;
+  letter-spacing: -0.8px;
+  line-height: 1.15;
+}
+
+.design-3 .blog-subtitle-v3 {
+  font-size: 17px;
+  color: rgba(var(--color-forest-rgb), 0.65);
+  margin: 0 0 24px;
+  line-height: 1.5;
+  max-width: 540px;
+}
+
+.design-3 .blog-actions-v3 {
+  display: flex;
+  gap: 16px;
+}
+
+.design-3 .blog-actions-v3 a {
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(var(--color-forest-rgb), 0.6);
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+
+.design-3 .blog-actions-v3 a:hover {
+  color: var(--color-forest);
+  border-bottom-color: var(--color-forest);
+  background: none;
+}
+
+.design-3 .blog-list-v3 {
+  display: flex;
+  flex-direction: column;
+}
+
+.design-3 .post-card-v3 {
+  display: flex;
+  align-items: flex-start;
+  gap: 24px;
+  padding: 28px 0;
+  border-top: 1px solid var(--color-highlight);
+  transition: background-color 0.2s ease;
+}
+
+.design-3 .post-card-v3:hover {
+  background-color: rgba(var(--color-forest-rgb), 0.02);
+  margin: 0 -20px;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.design-3 .post-card-v3:last-child {
+  border-bottom: 1px solid var(--color-highlight);
+}
+
+.design-3 .post-number-v3 {
+  flex-shrink: 0;
+  width: 28px;
+  font-size: 14px;
+  font-weight: 600;
+  color: rgba(var(--color-forest-rgb), 0.3);
+  padding-top: 4px;
+}
+
+.design-3 .post-main-v3 {
+  flex-grow: 1;
+}
+
+.design-3 .post-title-v3 {
+  font-family: "DM Serif Display", serif;
+  font-size: 22px;
+  line-height: 1.35;
+  margin: 0 0 8px;
+  letter-spacing: -0.2px;
+}
+
+.design-3 .post-title-v3 a {
+  color: inherit;
+  border-bottom: none;
+}
+
+.design-3 .post-title-v3 a:hover {
+  background: none;
+}
+
+.design-3 .post-summary-v3 {
+  font-size: 15px;
+  line-height: 1.55;
+  color: rgba(var(--color-forest-rgb), 0.65);
+  margin: 0 0 12px;
+}
+
+.design-3 .post-meta-v3 {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  font-size: 13px;
+  color: rgba(var(--color-forest-rgb), 0.45);
+}
+
+.design-3 .post-meta-v3 .tag {
+  padding: 3px 10px;
+  background-color: var(--color-highlight);
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: none;
+}
+
+.design-3 .post-meta-v3 .tag:hover {
+  background-color: var(--color-forest);
+  color: var(--color-mint);
+}
+
+.design-3 .post-thumbnail-v3 {
+  flex-shrink: 0;
+  width: 120px;
+  height: 80px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, var(--color-highlight), var(--color-surface));
+  overflow: hidden;
+  opacity: 0;
+  transform: translateX(10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.design-3 .post-card-v3:hover .post-thumbnail-v3 {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+@media (max-width: 600px) {
+  .design-3 .post-thumbnail-v3 {
+    display: none;
+  }
+}
+
+/* ============================================
+   INDIVIDUAL POST STYLES (shared preview)
+   ============================================ */
+.post-preview-section {
+  margin-top: 40px;
+  padding-top: 40px;
+  border-top: 1px dashed var(--color-highlight);
+}
+
+.post-preview-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: rgba(var(--color-forest-rgb), 0.5);
+  margin-bottom: 24px;
+}
+
+/* Design 1 Post */
+.design-1 .post-content-v1 {
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.design-1 .post-header-v1 {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.design-1 .post-header-v1 .post-meta-v1 {
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.design-1 .post-header-v1 .post-title-v1 {
+  font-size: 40px;
+  margin-bottom: 20px;
+}
+
+.design-1 .post-header-v1 .post-summary-v1 {
+  font-size: 20px;
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.design-1 .post-body-v1 {
+  font-size: 19px;
+  line-height: 1.8;
+  color: rgba(var(--color-forest-rgb), 0.85);
+}
+
+.design-1 .post-body-v1 p {
+  margin-bottom: 28px;
+  font-size: inherit;
+}
+
+/* Design 2 Post */
+.design-2 .post-content-v2-full {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.design-2 .post-hero-v2 {
+  margin-bottom: 48px;
+}
+
+.design-2 .post-hero-v2 .post-category-v2 {
+  margin-bottom: 16px;
+}
+
+.design-2 .post-hero-v2 .post-title-v2 {
+  font-size: 48px;
+  line-height: 1.15;
+  margin-bottom: 20px;
+}
+
+.design-2 .post-hero-v2 .post-summary-v2 {
+  font-size: 20px;
+  line-height: 1.5;
+}
+
+.design-2 .post-hero-v2 .post-meta-v2 {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding-top: 24px;
+  margin-top: 24px;
+  border-top: 1px solid var(--color-highlight);
+  font-size: 14px;
+  color: rgba(var(--color-forest-rgb), 0.6);
+}
+
+.design-2 .post-body-v2 {
+  font-size: 18px;
+  line-height: 1.75;
+}
+
+.design-2 .post-body-v2 p {
+  margin-bottom: 24px;
+  font-size: inherit;
+}
+
+/* Design 3 Post */
+.design-3 .post-content-v3-full {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.design-3 .post-header-v3 {
+  margin-bottom: 40px;
+  padding-bottom: 32px;
+  border-bottom: 1px solid var(--color-highlight);
+}
+
+.design-3 .post-header-v3 .post-title-v3 {
+  font-size: 36px;
+  line-height: 1.2;
+  margin-bottom: 16px;
+}
+
+.design-3 .post-header-v3 .post-summary-v3 {
+  font-size: 18px;
+  margin-bottom: 20px;
+}
+
+.design-3 .post-body-v3 {
+  font-size: 17px;
+  line-height: 1.75;
+}
+
+.design-3 .post-body-v3 p {
+  margin-bottom: 24px;
+  font-size: inherit;
+}
+
+.post-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 48px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.post-back-link:hover {
+  background: none;
+}
+</style>
+
+<div class="design-preview-page">
+  <header class="preview-header">
+    <h1>Blog Design Mockups</h1>
+    <p>Three design concepts for your blog, keeping your existing colors and fonts. Scroll to compare each option.</p>
+  </header>
+
+  <!-- DESIGN 1: MEDIUM-INSPIRED -->
+  <section class="design-section design-1">
+    <span class="design-label">Design 1</span>
+    <h2 style="font-family: 'DM Serif Display', serif; font-size: 28px; margin: 0 0 12px;">Medium-Inspired Minimal</h2>
+    <p class="design-description">Clean, reading-focused layout with generous whitespace. Single column with elegant typography and subtle dividers between posts. Inspired by Medium's focus on readability.</p>
+
+    <div class="mockup-container">
+      <div class="blog-index-v1">
+        <header class="blog-header-v1">
+          <h1 class="blog-title-v1">Blog</h1>
+          <p class="blog-subtitle-v1">Notes and longer writing on design leadership, product craft, and creative work.</p>
+          <div class="blog-actions-v1">
+            <a href="#">RSS Feed</a>
+            <a href="#">All Tags</a>
+          </div>
+        </header>
+
+        <div class="blog-list-v1">
+          <article class="post-card-v1">
+            <div class="post-meta-v1">
+              <time>Jan 10, 2026</time>
+              <span class="reading-time">4 min read</span>
+            </div>
+            <h2 class="post-title-v1"><a href="#">Hello World</a></h2>
+            <p class="post-summary-v1">This is my first post with my shiny new Eleventy blogging system. A reflection on building personal websites and why the simple approach often wins.</p>
+            <div class="post-tags-v1">
+              <a href="#">design</a>
+              <a href="#">AI</a>
+              <a href="#">web design</a>
+            </div>
+          </article>
+
+          <article class="post-card-v1">
+            <div class="post-meta-v1">
+              <time>Dec 28, 2025</time>
+              <span class="reading-time">7 min read</span>
+            </div>
+            <h2 class="post-title-v1"><a href="#">The Future of Design Systems</a></h2>
+            <p class="post-summary-v1">Exploring how design systems are evolving with AI tools and what this means for designers building products at scale.</p>
+            <div class="post-tags-v1">
+              <a href="#">design systems</a>
+              <a href="#">product</a>
+            </div>
+          </article>
+
+          <article class="post-card-v1">
+            <div class="post-meta-v1">
+              <time>Dec 15, 2025</time>
+              <span class="reading-time">5 min read</span>
+            </div>
+            <h2 class="post-title-v1"><a href="#">Leadership Through Craft</a></h2>
+            <p class="post-summary-v1">Why maintaining hands-on craft skills matters for design leaders, even as responsibilities shift toward strategy and management.</p>
+            <div class="post-tags-v1">
+              <a href="#">leadership</a>
+            </div>
+          </article>
+        </div>
+      </div>
+
+      <!-- Post Preview -->
+      <div class="post-preview-section">
+        <p class="post-preview-label">Individual Post Preview</p>
+        <div class="post-content-v1">
+          <header class="post-header-v1">
+            <div class="post-meta-v1">
+              <time>Jan 10, 2026</time>
+              <span class="reading-time">4 min read</span>
+            </div>
+            <h1 class="post-title-v1">Hello World</h1>
+            <p class="post-summary-v1">This is my first post with my shiny new Eleventy blogging system.</p>
+          </header>
+          <div class="post-body-v1">
+            <p>Welcome to my blog. This is where I'll be sharing thoughts on design, technology, and creative work. I've been meaning to start writing more regularly, and building this simple publishing system felt like the right first step.</p>
+            <p>There's something special about having a space that's truly yours on the internet. Social platforms come and go, algorithms change, but a personal website remains constant.</p>
+          </div>
+          <a href="#" class="post-back-link">← Back to Blog</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- DESIGN 2: EDITORIAL -->
+  <section class="design-section design-2">
+    <span class="design-label">Design 2</span>
+    <h2 style="font-family: 'DM Serif Display', serif; font-size: 28px; margin: 0 0 12px;">Editorial / Magazine</h2>
+    <p class="design-description">Visual, card-based layout with featured images and a two-column grid. Bold typography with clear hierarchy. First post is featured across full width.</p>
+
+    <div class="mockup-container">
+      <div class="blog-index-v2">
+        <header class="blog-header-v2">
+          <h1 class="blog-title-v2">Blog</h1>
+          <div class="blog-actions-v2">
+            <a href="#">RSS</a>
+            <a href="#">Tags</a>
+          </div>
+        </header>
+
+        <div class="blog-list-v2">
+          <article class="post-card-v2 featured">
+            <div class="post-image-v2">
+              <span class="placeholder-icon">◆</span>
+            </div>
+            <div class="post-content-v2">
+              <p class="post-category-v2">Featured</p>
+              <h2 class="post-title-v2"><a href="#">Hello World</a></h2>
+              <p class="post-summary-v2">This is my first post with my shiny new Eleventy blogging system. A reflection on building personal websites and why the simple approach often wins.</p>
+              <div class="post-footer-v2">
+                <span class="post-date-v2">Jan 10, 2026</span>
+                <a href="#" class="post-read-more-v2">Read More →</a>
+              </div>
+            </div>
+          </article>
+
+          <article class="post-card-v2">
+            <div class="post-image-v2">
+              <span class="placeholder-icon">◇</span>
+            </div>
+            <div class="post-content-v2">
+              <p class="post-category-v2">Design</p>
+              <h2 class="post-title-v2"><a href="#">The Future of Design Systems</a></h2>
+              <p class="post-summary-v2">Exploring how design systems are evolving with AI tools and what this means for designers.</p>
+              <div class="post-footer-v2">
+                <span class="post-date-v2">Dec 28, 2025</span>
+                <a href="#" class="post-read-more-v2">Read →</a>
+              </div>
+            </div>
+          </article>
+
+          <article class="post-card-v2">
+            <div class="post-image-v2">
+              <span class="placeholder-icon">○</span>
+            </div>
+            <div class="post-content-v2">
+              <p class="post-category-v2">Leadership</p>
+              <h2 class="post-title-v2"><a href="#">Leadership Through Craft</a></h2>
+              <p class="post-summary-v2">Why maintaining hands-on craft skills matters for design leaders.</p>
+              <div class="post-footer-v2">
+                <span class="post-date-v2">Dec 15, 2025</span>
+                <a href="#" class="post-read-more-v2">Read →</a>
+              </div>
+            </div>
+          </article>
+        </div>
+      </div>
+
+      <!-- Post Preview -->
+      <div class="post-preview-section">
+        <p class="post-preview-label">Individual Post Preview</p>
+        <div class="post-content-v2-full">
+          <header class="post-hero-v2">
+            <p class="post-category-v2">Design · AI · Web Design</p>
+            <h1 class="post-title-v2">Hello World</h1>
+            <p class="post-summary-v2">This is my first post with my shiny new Eleventy blogging system.</p>
+            <div class="post-meta-v2">
+              <time>January 10, 2026</time>
+              <span>·</span>
+              <span>4 min read</span>
+            </div>
+          </header>
+          <div class="post-body-v2">
+            <p>Welcome to my blog. This is where I'll be sharing thoughts on design, technology, and creative work. I've been meaning to start writing more regularly, and building this simple publishing system felt like the right first step.</p>
+            <p>There's something special about having a space that's truly yours on the internet. Social platforms come and go, algorithms change, but a personal website remains constant.</p>
+          </div>
+          <a href="#" class="post-back-link">← Back to Blog</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- DESIGN 3: CLEAN LIST -->
+  <section class="design-section design-3">
+    <span class="design-label">Design 3</span>
+    <h2 style="font-family: 'DM Serif Display', serif; font-size: 28px; margin: 0 0 12px;">Clean List / Minimal</h2>
+    <p class="design-description">Elegant list-based layout inspired by Paul Stamatiou. Numbered entries, subtle hover states with thumbnail reveal, and refined typography. Perfect for scanning.</p>
+
+    <div class="mockup-container">
+      <div class="blog-index-v3">
+        <header class="blog-header-v3">
+          <div class="author-intro">
+            <div class="author-avatar"></div>
+            <span class="author-name">Josiah Katz</span>
+          </div>
+          <h1 class="blog-title-v3">Writing & Notes</h1>
+          <p class="blog-subtitle-v3">Short notes and longer stories on design leadership, product craft, and creative work.</p>
+          <div class="blog-actions-v3">
+            <a href="#">RSS Feed</a>
+            <a href="#">Browse Tags</a>
+          </div>
+        </header>
+
+        <div class="blog-list-v3">
+          <article class="post-card-v3">
+            <span class="post-number-v3">01</span>
+            <div class="post-main-v3">
+              <h2 class="post-title-v3"><a href="#">Hello World</a></h2>
+              <p class="post-summary-v3">This is my first post with my shiny new Eleventy blogging system.</p>
+              <div class="post-meta-v3">
+                <time>Jan 10, 2026</time>
+                <a href="#" class="tag">design</a>
+                <a href="#" class="tag">AI</a>
+              </div>
+            </div>
+            <div class="post-thumbnail-v3"></div>
+          </article>
+
+          <article class="post-card-v3">
+            <span class="post-number-v3">02</span>
+            <div class="post-main-v3">
+              <h2 class="post-title-v3"><a href="#">The Future of Design Systems</a></h2>
+              <p class="post-summary-v3">Exploring how design systems are evolving with AI tools.</p>
+              <div class="post-meta-v3">
+                <time>Dec 28, 2025</time>
+                <a href="#" class="tag">design systems</a>
+              </div>
+            </div>
+            <div class="post-thumbnail-v3"></div>
+          </article>
+
+          <article class="post-card-v3">
+            <span class="post-number-v3">03</span>
+            <div class="post-main-v3">
+              <h2 class="post-title-v3"><a href="#">Leadership Through Craft</a></h2>
+              <p class="post-summary-v3">Why maintaining hands-on craft skills matters for design leaders.</p>
+              <div class="post-meta-v3">
+                <time>Dec 15, 2025</time>
+                <a href="#" class="tag">leadership</a>
+              </div>
+            </div>
+            <div class="post-thumbnail-v3"></div>
+          </article>
+        </div>
+      </div>
+
+      <!-- Post Preview -->
+      <div class="post-preview-section">
+        <p class="post-preview-label">Individual Post Preview</p>
+        <div class="post-content-v3-full">
+          <header class="post-header-v3">
+            <div class="post-meta-v3" style="margin-bottom: 16px;">
+              <time>Jan 10, 2026</time>
+              <a href="#" class="tag">design</a>
+              <a href="#" class="tag">AI</a>
+            </div>
+            <h1 class="post-title-v3">Hello World</h1>
+            <p class="post-summary-v3">This is my first post with my shiny new Eleventy blogging system.</p>
+          </header>
+          <div class="post-body-v3">
+            <p>Welcome to my blog. This is where I'll be sharing thoughts on design, technology, and creative work. I've been meaning to start writing more regularly, and building this simple publishing system felt like the right first step.</p>
+            <p>There's something special about having a space that's truly yours on the internet. Social platforms come and go, algorithms change, but a personal website remains constant.</p>
+          </div>
+          <a href="#" class="post-back-link">← Back to Blog</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</div>

--- a/content/blog/index.njk
+++ b/content/blog/index.njk
@@ -10,8 +10,8 @@ mainClass: blog
     <h1 class="blog-title">Blog</h1>
     <p class="blog-subtitle">Short notes and longer stories on design leadership, product craft, and creative work.</p>
     <div class="blog-actions">
-      <a class="section-link" href="/blog/feed.xml">RSS</a>
-      <a class="section-link" href="/blog/tags/">Tags</a>
+      <a href="/blog/feed.xml">RSS Feed</a>
+      <a href="/blog/tags/">All Tags</a>
     </div>
   </div>
   <div class="blog-list">

--- a/package-lock.json
+++ b/package-lock.json
@@ -474,7 +474,6 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "eleventy",
     "dev": "eleventy --watch",
-    "serve": "npx wrangler pages dev . --ip 127.0.0.1 --port 8788",
+    "serve": "npx wrangler pages dev dist --ip 127.0.0.1 --port 8788",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/styles.css
+++ b/styles.css
@@ -625,107 +625,200 @@ footer {
 	}
 }
 
-/* Blog */
+/* Blog - Design 1: Medium-Inspired Minimal */
 main.blog,
 main.page {
-	width: min(900px, 90vw);
+	max-width: 680px;
 	margin: 0 auto 80px;
+	padding: 0 20px;
 }
 .blog-index {
 	display: flex;
 	flex-direction: column;
-	gap: 32px;
+	gap: 0;
 }
 .blog-header {
-	display: flex;
-	flex-direction: column;
-	gap: 12px;
+	text-align: center;
+	padding-bottom: 48px;
+	margin-bottom: 48px;
+	border-bottom: 1px solid var(--color-highlight);
 }
 .blog-title {
 	font-family: "DM Serif Display", serif;
-	font-size: clamp(36px, 6vw, 60px);
-	text-transform: none;
-	letter-spacing: -0.5px;
-	margin: 0;
+	font-size: 48px;
+	margin: 0 0 12px;
+	letter-spacing: -1px;
 }
 .blog-subtitle {
-	margin: 0;
-	font-size: 16px;
-	max-width: 620px;
+	font-size: 18px;
+	color: rgba(var(--color-forest-rgb), 0.65);
+	margin: 0 0 24px;
+	line-height: 1.5;
 }
 .blog-actions {
 	display: flex;
-	gap: 16px;
-	flex-wrap: wrap;
-}
-.blog-list {
-	display: grid;
+	justify-content: center;
 	gap: 24px;
 }
+.blog-actions a {
+	font-size: 13px;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	font-weight: 600;
+	color: rgba(var(--color-forest-rgb), 0.6);
+	border-bottom: none;
+	transition: color 0.2s ease;
+}
+.blog-actions a:hover {
+	color: var(--color-forest);
+	background: none;
+}
+.blog-list {
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+}
 .post-card {
-	padding: 20px;
-	border-radius: 16px;
-	border: 1px solid var(--color-highlight);
-	background-color: var(--color-surface);
-	box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
-	transition: transform 0.2s ease, box-shadow 0.2s ease;
+	padding: 40px 0;
+	border-bottom: 1px solid var(--color-highlight);
+	background: none;
+	border-radius: 0;
+	box-shadow: none;
+	transition: none;
+}
+.post-card:first-child {
+	padding-top: 0;
+}
+.post-card:last-child {
+	border-bottom: none;
 }
 .post-card:hover {
-	transform: translateY(-2px);
-	box-shadow: 0 14px 32px rgba(0, 0, 0, 0.08);
+	transform: none;
+	box-shadow: none;
 }
 .post-meta {
 	display: flex;
-	flex-wrap: wrap;
+	align-items: center;
 	gap: 12px;
-	margin: 0 0 8px;
-	font-size: 11px;
-	text-transform: uppercase;
-	letter-spacing: 2px;
-	color: rgba(var(--color-forest-rgb), 0.7);
+	margin: 0 0 16px;
+	font-size: 13px;
+	color: rgba(var(--color-forest-rgb), 0.55);
+	text-transform: none;
+	letter-spacing: 0;
+}
+.post-meta time {
+	font-weight: 500;
 }
 .post-title {
 	font-family: "DM Serif Display", serif;
-	font-size: 26px;
-	margin: 0 0 8px;
-	text-transform: none;
+	font-size: 28px;
+	line-height: 1.25;
+	margin: 0 0 12px;
 	letter-spacing: -0.3px;
 }
 .post-title a {
+	color: inherit;
 	border-bottom: none;
+	transition: color 0.2s ease;
+}
+.post-title a:hover {
+	color: rgba(var(--color-forest-rgb), 0.7);
+	background: none;
 }
 .post-summary {
-	margin: 0;
-	font-size: 16px;
+	font-size: 17px;
+	line-height: 1.6;
+	color: rgba(var(--color-forest-rgb), 0.75);
+	margin: 0 0 16px;
 }
 .post-tags {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 8px;
-	margin-top: 10px;
 }
 .post-tags a {
-	font-size: 11px;
-	text-transform: uppercase;
-	letter-spacing: 2px;
+	font-size: 12px;
+	font-weight: 500;
+	color: rgba(var(--color-forest-rgb), 0.55);
 	border-bottom: none;
-	padding: 4px 10px;
-	border-radius: 999px;
-	border: 1px solid var(--color-highlight);
-	background-color: var(--color-surface-muted);
+	padding: 0;
+	background: none;
+	border-radius: 0;
+	border: none;
+	text-transform: none;
+	letter-spacing: 0;
+}
+.post-tags a:hover {
+	color: var(--color-forest);
+	background: none;
+}
+.blog-post {
+	max-width: 680px;
+	margin: 0 auto;
 }
 .blog .post-header {
-	margin-bottom: 24px;
+	text-align: center;
+	margin-bottom: 48px;
+}
+.blog .post-header .post-meta {
+	justify-content: center;
+	margin-bottom: 20px;
+}
+.blog .post-header .post-title {
+	font-size: 40px;
+	margin-bottom: 20px;
+}
+.blog .post-header .post-summary {
+	font-size: 20px;
+	max-width: 560px;
+	margin: 0 auto;
 }
 .blog .post-body {
-	font-size: 18px;
-	line-height: 1.7;
+	font-size: 19px;
+	line-height: 1.8;
+	color: rgba(var(--color-forest-rgb), 0.85);
+}
+.blog .post-body p {
+	margin-bottom: 28px;
+	font-size: inherit;
 }
 .blog .post-body img {
 	display: block;
 	width: 100%;
 	border-radius: 20px;
 	border: 1px solid var(--color-highlight);
+}
+.post-tags-footer {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-top: 32px;
+	padding-top: 24px;
+	border-top: 1px solid var(--color-highlight);
+}
+.post-tags-footer a {
+	font-size: 12px;
+	font-weight: 500;
+	color: rgba(var(--color-forest-rgb), 0.55);
+	border-bottom: none;
+	padding: 0;
+}
+.post-tags-footer a:hover {
+	color: var(--color-forest);
+	background: none;
+}
+.post-back {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	margin-top: 32px;
+	font-size: 13px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 1px;
+}
+.post-back a:hover {
+	background: none;
 }
 .notes-list {
 	display: grid;

--- a/styles.css
+++ b/styles.css
@@ -788,25 +788,6 @@ main.page {
 	border-radius: 20px;
 	border: 1px solid var(--color-highlight);
 }
-.post-tags-footer {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 8px;
-	margin-top: 32px;
-	padding-top: 24px;
-	border-top: 1px solid var(--color-highlight);
-}
-.post-tags-footer a {
-	font-size: 12px;
-	font-weight: 500;
-	color: rgba(var(--color-forest-rgb), 0.55);
-	border-bottom: none;
-	padding: 0;
-}
-.post-tags-footer a:hover {
-	color: var(--color-forest);
-	background: none;
-}
 .post-back {
 	display: inline-flex;
 	align-items: center;


### PR DESCRIPTION
Created a design preview page at /blog/design-preview/ showing
three alternative blog layout concepts:

1. Medium-Inspired Minimal - Clean reading focus, generous whitespace,
   centered single column with elegant typography and subtle dividers

2. Editorial/Magazine - Visual card-based layout with featured images,
   two-column grid, and bold typography with clear hierarchy

3. Clean List (Stamatiou-inspired) - Numbered list entries with
   subtle hover states and thumbnail reveal on hover

All designs preserve existing colors (mint, forest, highlight) and
fonts (Manrope, DM Serif Display). Includes both blog index and
individual post previews for each design.