### PR TITLE
Fix mobile carousel scrolling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -492,7 +492,6 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1169,7 +1168,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/styles.css
+++ b/styles.css
@@ -443,6 +443,17 @@ footer {
 	padding: 20px 0;
 	margin: -20px 0;
 }
+@media (max-width:700px) {
+	.carousel__track {
+		overflow-x: auto;
+		-webkit-overflow-scrolling: touch;
+		scroll-snap-type: x mandatory;
+	}
+	.media-row {
+		transform: none !important;
+		transition: none !important;
+	}
+}
 .carousel__btn {
 	position: absolute;
 	top: 50%;


### PR DESCRIPTION
Enable native touch scrolling on mobile devices by:
- Adding overflow-x: auto to .carousel__track on mobile
- Adding smooth iOS scrolling with -webkit-overflow-scrolling: touch
- Enabling scroll-snap-type: x mandatory for better UX
- Disabling JS transform positioning on mobile to use native scroll